### PR TITLE
Destroy jq-scalebreaker popup on hide.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Translate",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Translate extension allows you to easily translate selected text into English.",
   "private": "true",
   "scripts": {

--- a/src/vendor/jquery-ui-scalebreaker/jq-scalebreaker.coffee
+++ b/src/vendor/jquery-ui-scalebreaker/jq-scalebreaker.coffee
@@ -17,6 +17,7 @@
       refreshOnScroll: true
       mobileFriendlyInitialWidth: 320
       mobileFriendlyMaxWidth: 568
+      broadcastEvents: true
       debug: false
 
     _create: ->
@@ -43,6 +44,7 @@
       @isMobileBrowser = (/iPhone|iPod|Android|BlackBerry/).test(navigator.userAgent)
       @state = 'hidden'
       @_initWidget()
+      @_logMessage 'widget created', @wrapper
 
     _initWidget: ->
       # Append the basic wrapper to the DOM.
@@ -131,9 +133,13 @@
       else if @scrollbar
         @scrollbar.refresh()
 
+    _triggerEvent: (name, data) ->
+      @element.trigger name, [data]
+      @_logMessage name, data
+
     _logMessage: (name, args) ->
       if @options.debug
-        console.log "#{@options.idNamespace}: #{name}", args
+        console.log "jq-scalebreaker: #{name}", args
 
     show: ->
       _self = this
@@ -166,7 +172,8 @@
         $(window).on "scroll.#{@options.idNamespace}",(e) ->
           _self.refresh()
       @state = 'shown'
-      @_logMessage 'showing widget'
+      if @options.broadcastEvents
+        @_triggerEvent "dialogShown.#{@options.idNamespace}", @wrapper
 
     hide: ->
       _self = this
@@ -194,7 +201,8 @@
       if @options.refreshOnScroll
         $(window).off "scroll.#{@options.idNamespace}"
       @state = 'hidden'
-      @_logMessage 'hiding widget'
+      if @options.broadcastEvents
+        @_triggerEvent "dialogHidden.#{@options.idNamespace}", @wrapper
 
     changeDialogContent: (content) ->
       @content.html content
@@ -216,7 +224,7 @@
       @_manageScrollbar()
       @_logMessage 'refreshing'
 
-    destroy: ->
+    _destroy: ->
       $(window).off "scroll.#{@options.idNamespace}"
       @wrapper.remove()
       @rawElement = null
@@ -231,8 +239,6 @@
       if @scrollbar
         @scrollbar.destroy()
       @scrollbar = null
-      @_destroy()
-
-    _destroy: $.noop
+      @_logMessage 'widget instance destroyed'
 
 ) jQuery

--- a/src/vendor/jquery-ui-scalebreaker/jq-scalebreaker.js
+++ b/src/vendor/jquery-ui-scalebreaker/jq-scalebreaker.js
@@ -12,6 +12,7 @@
         refreshOnScroll: true,
         mobileFriendlyInitialWidth: 320,
         mobileFriendlyMaxWidth: 568,
+        broadcastEvents: true,
         debug: false
       },
       _create: function() {
@@ -27,7 +28,8 @@
         this.currentViewportOffset = null;
         this.isMobileBrowser = /iPhone|iPod|Android|BlackBerry/.test(navigator.userAgent);
         this.state = 'hidden';
-        return this._initWidget();
+        this._initWidget();
+        return this._logMessage('widget created', this.wrapper);
       },
       _initWidget: function() {
         $('body').append(this.rawElement);
@@ -115,9 +117,13 @@
           return this.scrollbar.refresh();
         }
       },
+      _triggerEvent: function(name, data) {
+        this.element.trigger(name, [data]);
+        return this._logMessage(name, data);
+      },
       _logMessage: function(name, args) {
         if (this.options.debug) {
-          return console.log("" + this.options.idNamespace + ": " + name, args);
+          return console.log("jq-scalebreaker: " + name, args);
         }
       },
       show: function() {
@@ -155,7 +161,9 @@
           });
         }
         this.state = 'shown';
-        return this._logMessage('showing widget');
+        if (this.options.broadcastEvents) {
+          return this._triggerEvent("dialogShown." + this.options.idNamespace, this.wrapper);
+        }
       },
       hide: function() {
         var _self;
@@ -181,7 +189,9 @@
           $(window).off("scroll." + this.options.idNamespace);
         }
         this.state = 'hidden';
-        return this._logMessage('hiding widget');
+        if (this.options.broadcastEvents) {
+          return this._triggerEvent("dialogHidden." + this.options.idNamespace, this.wrapper);
+        }
       },
       changeDialogContent: function(content) {
         this.content.html(content);
@@ -201,7 +211,7 @@
         this._manageScrollbar();
         return this._logMessage('refreshing');
       },
-      destroy: function() {
+      _destroy: function() {
         $(window).off("scroll." + this.options.idNamespace);
         this.wrapper.remove();
         this.rawElement = null;
@@ -217,9 +227,8 @@
           this.scrollbar.destroy();
         }
         this.scrollbar = null;
-        return this._destroy();
-      },
-      _destroy: $.noop
+        return this._logMessage('widget instance destroyed');
+      }
     });
   })(jQuery);
 


### PR DESCRIPTION
The code is a little ugly, mostly because scalebreaker doesn't seem to support the "destroy to hide" paradigm. In particular, I don't know how to check if `scalebreaker` exists when it's not instantiated. Maybe some sort of static method on the scalebreaker factory could help here? (@filipnaumovic ?)
